### PR TITLE
add versions to gradle to prevent incompatibility when updates occur

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,14 +51,14 @@ tasks.withType(com.github.spotbugs.SpotBugsTask) {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
-	implementation 'org.springframework.boot:spring-boot-starter-jdbc'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	runtimeOnly 'com.h2database:h2'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	compile("org.springframework.boot:spring-boot-starter-security")
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest:2.1.2.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-jdbc:2.1.2.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf:2.1.2.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-web:2.1.2.RELEASE'
+	runtimeOnly 'com.h2database:h2:1.4.197'
+	compileOnly 'org.projectlombok:lombok:1.18.4'
+	annotationProcessor 'org.projectlombok:lombok:1.18.4'
+	compile 'org.springframework.boot:spring-boot-starter-security:2.1.2.RELEASE'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test:2.1.2.RELEASE'
+	testImplementation 'org.springframework.security:spring-security-test:5.1.3.RELEASE'
 }


### PR DESCRIPTION
Ist nicht dringend, so verhindern wir aber, dass irgendwas updatet und dann vll nicht mehr funktioniert.