### PR TITLE
Bugfix: Docker Port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,6 @@ services:
   datenbank:
     container_name: datenbank
     image: oscarfonts/h2
-    ports:
-      - "1521:1521"
     environment:
       - H2_DATABASE=datenbank
       - H2_USER=perfectlybalanced


### PR DESCRIPTION
Datenbank-Port wird nicht mehr öffentlich freigegeben.
Zugang wird über application-prod.properties aufgerufen